### PR TITLE
Update field names in CustomerController

### DIFF
--- a/src/main/java/com/cognizant/customerservice/controller/CustomerController.java
+++ b/src/main/java/com/cognizant/customerservice/controller/CustomerController.java
@@ -28,10 +28,10 @@ import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 public class CustomerController {  // /customer endpoint
 
 	@Autowired
-	private CustomerService customerService;  //customer interface
+	private CustomerService CustomerService;  //customer interface
 
 	@Autowired
-	AuthorizationFeign authorizationFeign;   //auth feign
+	AuthorizationFeign Authorizationfeign;   //auth feign
 
 	/**
 	 * @param token


### PR DESCRIPTION
Renamed 'customerService' to 'CustomerService' and 'authorizationFeign' to 'Authorizationfeign' to follow a different naming convention in CustomerController.